### PR TITLE
Update code to use new github repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ deplab generates and shows metadata about a container image's dependencies.
 
 ## Obtain
 
-Download the latest deplab release matching your OS from https://github.com/pivotal/deplab/releases/latest. Make it executable and move it to a directory in your `PATH` renaming it `deplab`.
+Download the latest deplab release matching your OS from https://github.com/vmware-tanzu/dependency-labeler/releases/latest. Make it executable and move it to a directory in your `PATH` renaming it `deplab`.
 
 ## Usage
 
@@ -302,7 +302,7 @@ Example of `apt_sources` content
              "commit":  "d2c[...]efd"
             },
            "metadata": {
-             "url": "https://github.com/pivotal/deplab.git",
+             "url": "https://github.com/vmware-tanzu/dependency-labeler.git",
              "refs": ["0.5.0"]
            }
          }
@@ -362,7 +362,7 @@ Provenance is a list of the tools which have added information to the image. It 
     {
       "name": "deplab",
       "version": "0.0.0-dev",
-      "url": "https://github.com/pivotal/deplab"
+      "url": "https://github.com/vmware-tanzu/dependency-labeler"
     }
   ]
 ```

--- a/cmd/deplab/inspect.go
+++ b/cmd/deplab/inspect.go
@@ -6,7 +6,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/pivotal/deplab/pkg/deplab"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/deplab"
 
 	"github.com/spf13/cobra"
 )

--- a/cmd/deplab/main.go
+++ b/cmd/deplab/main.go
@@ -8,9 +8,9 @@ import (
 	"log"
 	"os"
 
-	"github.com/pivotal/deplab/pkg/common"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/common"
 
-	"github.com/pivotal/deplab/pkg/deplab"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/deplab"
 
 	"github.com/spf13/cobra"
 )
@@ -46,7 +46,7 @@ var rootCmd = &cobra.Command{
 	Short: "dependency labeler adds a metadata label to a container image",
 	Long: `Dependency labeler adds information about a container image to that image's config. 
 	The information can be found in a "io.deplab.metadata" label on the output image. 
-	Complete documentation is available at http://github.com/pivotal/deplab`,
+	Complete documentation is available at http://github.com/vmware-tanzu/dependency-labeler`,
 	Version: deplab.Version,
 
 	PreRunE: validateFlags,

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 // Copyright (c) 2019-2020 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: BSD-2-Clause
 
-module github.com/pivotal/deplab
+module github.com/vmware-tanzu/dependency-labeler
 
 go 1.12
 

--- a/pkg/additionalsources/archives.go
+++ b/pkg/additionalsources/archives.go
@@ -9,11 +9,11 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/pivotal/deplab/pkg/common"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/common"
 
-	"github.com/pivotal/deplab/pkg/image"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/image"
 
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 )
 
 type HTTPHeadFn func(url string) (resp *http.Response, err error)

--- a/pkg/additionalsources/archives_test.go
+++ b/pkg/additionalsources/archives_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	. "github.com/pivotal/deplab/pkg/additionalsources"
+	. "github.com/vmware-tanzu/dependency-labeler/pkg/additionalsources"
 )
 
 var _ = Describe("additionalsources", func() {

--- a/pkg/additionalsources/sources.go
+++ b/pkg/additionalsources/sources.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pivotal/deplab/pkg/git"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/git"
 
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 
 	"gopkg.in/yaml.v2"
 )

--- a/pkg/cnb/provider.go
+++ b/pkg/cnb/provider.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/pivotal/deplab/pkg/common"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/common"
 
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 	"golang.org/x/text/collate"
 	"golang.org/x/text/language"
 
-	"github.com/pivotal/deplab/pkg/image"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/image"
 )
 
 func Provider(dli image.Image, _ common.RunParams, md metadata.Metadata) (metadata.Metadata, error) {

--- a/pkg/cnb/provider_test.go
+++ b/pkg/cnb/provider_test.go
@@ -6,10 +6,10 @@ package cnb_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/pivotal/deplab/pkg/cnb"
-	"github.com/pivotal/deplab/pkg/common"
-	"github.com/pivotal/deplab/pkg/metadata"
-	"github.com/pivotal/deplab/test/test_utils"
+	. "github.com/vmware-tanzu/dependency-labeler/pkg/cnb"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/common"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/test/test_utils"
 )
 
 var _ = Describe("Cnb", func() {

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -6,8 +6,8 @@ package common_test
 import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/pivotal/deplab/pkg/common"
-	"github.com/pivotal/deplab/pkg/metadata"
+	. "github.com/vmware-tanzu/dependency-labeler/pkg/common"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 )
 
 var _ = Describe("Digest", func() {

--- a/pkg/deplab/deplab.go
+++ b/pkg/deplab/deplab.go
@@ -7,25 +7,25 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/pivotal/deplab/pkg/kpack"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/kpack"
 	"os"
 	"strings"
 
-	"github.com/pivotal/deplab/pkg/cnb"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/cnb"
 
-	"github.com/pivotal/deplab/pkg/additionalsources"
-	"github.com/pivotal/deplab/pkg/common"
-	"github.com/pivotal/deplab/pkg/rpm"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/additionalsources"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/common"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/rpm"
 
-	"github.com/pivotal/deplab/pkg/git"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/git"
 
-	"github.com/pivotal/deplab/pkg/dpkg"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/dpkg"
 
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 
-	"github.com/pivotal/deplab/pkg/osrelease"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/osrelease"
 
-	"github.com/pivotal/deplab/pkg/image"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/image"
 )
 
 type provider func(image.Image, common.RunParams, metadata.Metadata) (metadata.Metadata, error)
@@ -34,7 +34,7 @@ var Version = "0.0.0-dev"
 var Provenance = metadata.Provenance{
 	Name:    "deplab",
 	Version: Version,
-	URL:     "https://github.com/pivotal/deplab",
+	URL:     "https://github.com/vmware-tanzu/dependency-labeler",
 }
 
 func Run(params common.RunParams) error {

--- a/pkg/dpkg/output.go
+++ b/pkg/dpkg/output.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 )
 
 func WriteDpkgFile(md metadata.Metadata, dpkgFilePath string, deplabVersion string) error {

--- a/pkg/dpkg/output_test.go
+++ b/pkg/dpkg/output_test.go
@@ -9,9 +9,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/extensions/table"
 	"github.com/onsi/gomega"
-	"github.com/pivotal/deplab/pkg/dpkg"
-	"github.com/pivotal/deplab/pkg/metadata"
-	"github.com/pivotal/deplab/test/test_utils"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/dpkg"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/test/test_utils"
 )
 
 var _ = Describe("dpkg", func() {

--- a/pkg/dpkg/provider.go
+++ b/pkg/dpkg/provider.go
@@ -8,11 +8,11 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/pivotal/deplab/pkg/common"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/common"
 
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 
-	"github.com/pivotal/deplab/pkg/image"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/image"
 
 	"golang.org/x/text/collate"
 	"golang.org/x/text/language"

--- a/pkg/dpkg/provider_test.go
+++ b/pkg/dpkg/provider_test.go
@@ -4,13 +4,13 @@
 package dpkg_test
 
 import (
-	"github.com/pivotal/deplab/pkg/common"
-	"github.com/pivotal/deplab/test/test_utils"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/common"
+	"github.com/vmware-tanzu/dependency-labeler/test/test_utils"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/pivotal/deplab/pkg/dpkg"
-	"github.com/pivotal/deplab/pkg/metadata"
+	. "github.com/vmware-tanzu/dependency-labeler/pkg/dpkg"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 )
 
 var _ = Describe("Dpkg", func() {

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -6,11 +6,11 @@ package git
 import (
 	"fmt"
 
-	"github.com/pivotal/deplab/pkg/common"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/common"
 
-	"github.com/pivotal/deplab/pkg/image"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/image"
 
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -9,7 +9,7 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 
 	"github.com/containerd/containerd/reference/docker"
 

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -8,12 +8,12 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/pivotal/deplab/pkg/image"
+	. "github.com/vmware-tanzu/dependency-labeler/pkg/image"
 )
 
 var _ = Describe("Image", func() {

--- a/pkg/image/rootfs_test.go
+++ b/pkg/image/rootfs_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "github.com/pivotal/deplab/pkg/image"
+	. "github.com/vmware-tanzu/dependency-labeler/pkg/image"
 )
 
 var rfs RootFS

--- a/pkg/kpack/provider.go
+++ b/pkg/kpack/provider.go
@@ -6,9 +6,9 @@ package kpack
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/pivotal/deplab/pkg/common"
-	"github.com/pivotal/deplab/pkg/image"
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/common"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/image"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 )
 
 type RepoSource struct {

--- a/pkg/kpack/provider_test.go
+++ b/pkg/kpack/provider_test.go
@@ -7,10 +7,10 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal/deplab/pkg/common"
-	. "github.com/pivotal/deplab/pkg/kpack"
-	"github.com/pivotal/deplab/pkg/metadata"
-	"github.com/pivotal/deplab/test/test_utils"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/common"
+	. "github.com/vmware-tanzu/dependency-labeler/pkg/kpack"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/test/test_utils"
 )
 
 type MockImage struct {

--- a/pkg/metadata/merge_test.go
+++ b/pkg/metadata/merge_test.go
@@ -9,8 +9,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal/deplab/pkg/metadata"
-	"github.com/pivotal/deplab/test/test_utils"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/test/test_utils"
 )
 
 var _ = Describe("Merge", func() {

--- a/pkg/metadata/output_test.go
+++ b/pkg/metadata/output_test.go
@@ -6,13 +6,13 @@ package metadata_test
 import (
 	"io/ioutil"
 
-	"github.com/pivotal/deplab/test/test_utils"
+	"github.com/vmware-tanzu/dependency-labeler/test/test_utils"
 
 	. "github.com/onsi/ginkgo"
 
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	. "github.com/pivotal/deplab/pkg/metadata"
+	. "github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 )
 
 var _ = Describe("outputs", func() {

--- a/pkg/osrelease/provider.go
+++ b/pkg/osrelease/provider.go
@@ -6,11 +6,11 @@ package osrelease
 import (
 	"strings"
 
-	"github.com/pivotal/deplab/pkg/common"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/common"
 
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 
-	"github.com/pivotal/deplab/pkg/image"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/image"
 
 	"github.com/joho/godotenv"
 )

--- a/pkg/osrelease/provider_test.go
+++ b/pkg/osrelease/provider_test.go
@@ -8,8 +8,8 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal/deplab/pkg/metadata"
-	. "github.com/pivotal/deplab/pkg/osrelease"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
+	. "github.com/vmware-tanzu/dependency-labeler/pkg/osrelease"
 )
 
 type MockImage struct {

--- a/pkg/rpm/packages.go
+++ b/pkg/rpm/packages.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 )
 
 const sep = "\t"

--- a/pkg/rpm/provider.go
+++ b/pkg/rpm/provider.go
@@ -11,14 +11,14 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/pivotal/deplab/pkg/common"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/common"
 
-	"github.com/pivotal/deplab/pkg/image"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/image"
 
 	"golang.org/x/text/collate"
 	"golang.org/x/text/language"
 
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 )
 
 const RPMDbPath = "/var/lib/rpm"

--- a/pkg/rpm/provider_test.go
+++ b/pkg/rpm/provider_test.go
@@ -4,8 +4,8 @@
 package rpm_test
 
 import (
-	"github.com/pivotal/deplab/pkg/common"
-	"github.com/pivotal/deplab/test/test_utils"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/common"
+	"github.com/vmware-tanzu/dependency-labeler/test/test_utils"
 	"io/ioutil"
 	"os"
 
@@ -15,8 +15,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal/deplab/pkg/metadata"
-	"github.com/pivotal/deplab/pkg/rpm"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/rpm"
 
 	"path/filepath"
 )

--- a/test/integration/additional_source_url_integration_test.go
+++ b/test/integration/additional_source_url_integration_test.go
@@ -6,7 +6,7 @@ package integration_test
 import (
 	"net/http"
 
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/test/integration/additional_sources_file_integration_test.go
+++ b/test/integration/additional_sources_file_integration_test.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 
-	"github.com/pivotal/deplab/test/test_utils"
+	"github.com/vmware-tanzu/dependency-labeler/test/test_utils"
 
 	"github.com/onsi/gomega/ghttp"
 
@@ -118,7 +118,7 @@ var _ = Describe("deplab additional sources file", func() {
 				Expect(gitDependency.Source.Version["commit"]).To(Equal("abc123"))
 
 				By("adding the git remote to a git dependency")
-				Expect(gitSourceMetadata["url"].(string)).To(Equal("git@github.com:pivotal/deplab.git"))
+				Expect(gitSourceMetadata["url"].(string)).To(Equal("git@github.com:vmware-tanzu/dependency-labeler.git"))
 			})
 		})
 
@@ -248,7 +248,7 @@ var _ = Describe("deplab additional sources file", func() {
 				errorOutput := strings.TrimSpace(string(getContentsOfReader(stdErr)))
 				Expect(errorOutput).To(SatisfyAll(
 					ContainSubstring("error"),
-					ContainSubstring("pivotal/deplab.git"),
+					ContainSubstring("vmware-tanzu/dependency-labeler.git"),
 				))
 			})
 
@@ -271,7 +271,7 @@ var _ = Describe("deplab additional sources file", func() {
 					errorOutput := strings.TrimSpace(string(getContentsOfReader(stdErr)))
 					Expect(errorOutput).To(SatisfyAll(
 						ContainSubstring("warning"),
-						ContainSubstring("pivotal/deplab.git"),
+						ContainSubstring("vmware-tanzu/dependency-labeler.git"),
 					))
 
 					By("by including a vcs git dependency")

--- a/test/integration/assets/sources/sources-file-multiple-archives-multiple-vcs.yml
+++ b/test/integration/assets/sources/sources-file-multiple-archives-multiple-vcs.yml
@@ -1,7 +1,7 @@
 vcs:
   - protocol: git
     version: abc123
-    url: git@github.com:pivotal/deplab.git
+    url: git@github.com:vmware-tanzu/dependency-labeler.git
   - protocol: git
     version: def456
     url: git@github.com:cloudfoundry/stacks.git

--- a/test/integration/assets/sources/sources-file-single-vcs.yml
+++ b/test/integration/assets/sources/sources-file-single-vcs.yml
@@ -1,5 +1,5 @@
 vcs:
   - protocol: git
     version: abc123
-    url: git@github.com:pivotal/deplab.git
+    url: git@github.com:vmware-tanzu/dependency-labeler.git
     refs: v0.44.0

--- a/test/integration/assets/sources/sources-invalid-git-url.yml
+++ b/test/integration/assets/sources/sources-invalid-git-url.yml
@@ -1,5 +1,5 @@
 vcs:
   - protocol: git
     version: abc123
-    url: pivotal/deplab.git
+    url: vmware-tanzu/dependency-labeler.git
     refs: v0.44.0

--- a/test/integration/buildpacks_integration_test.go
+++ b/test/integration/buildpacks_integration_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"sort"
 
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 	"golang.org/x/text/collate"
 	"golang.org/x/text/language"
 

--- a/test/integration/deplab_flag_validation_integration_test.go
+++ b/test/integration/deplab_flag_validation_integration_test.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 
 	"github.com/onsi/gomega/ghttp"
 

--- a/test/integration/dpkg_file_integration_test.go
+++ b/test/integration/dpkg_file_integration_test.go
@@ -6,7 +6,7 @@ package integration_test
 import (
 	"io/ioutil"
 
-	"github.com/pivotal/deplab/test/test_utils"
+	"github.com/vmware-tanzu/dependency-labeler/test/test_utils"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/test/integration/dpkg_integration_test.go
+++ b/test/integration/dpkg_integration_test.go
@@ -6,9 +6,9 @@ package integration_test
 import (
 	"sort"
 
-	"github.com/pivotal/deplab/test/test_utils"
+	"github.com/vmware-tanzu/dependency-labeler/test/test_utils"
 
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 
 	"golang.org/x/text/collate"
 	"golang.org/x/text/language"

--- a/test/integration/git_integation_test.go
+++ b/test/integration/git_integation_test.go
@@ -4,7 +4,7 @@
 package integration_test
 
 import (
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/test/integration/inspect_integration_test.go
+++ b/test/integration/inspect_integration_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 
 	"github.com/onsi/gomega/ghttp"
 
@@ -46,7 +46,7 @@ func TestDeplab(t *testing.T) {
 
 		commitHash, pathToGitRepo = makeFakeGitRepo()
 
-		pathToBin, err = gexec.Build("github.com/pivotal/deplab/cmd/deplab")
+		pathToBin, err = gexec.Build("github.com/vmware-tanzu/dependency-labeler/cmd/deplab")
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/test/integration/kpack_integration_test.go
+++ b/test/integration/kpack_integration_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 )
 
 var _ = Describe("deplab", func() {

--- a/test/integration/metadata_file_integation_test.go
+++ b/test/integration/metadata_file_integation_test.go
@@ -4,7 +4,7 @@
 package integration_test
 
 import (
-	"github.com/pivotal/deplab/test/test_utils"
+	"github.com/vmware-tanzu/dependency-labeler/test/test_utils"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/test/integration/output_tar_integration_test.go
+++ b/test/integration/output_tar_integration_test.go
@@ -12,12 +12,12 @@ import (
 	"path"
 	"strings"
 
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 
 	"github.com/google/go-containerregistry/pkg/crane"
 
 	. "github.com/onsi/ginkgo/extensions/table"
-	"github.com/pivotal/deplab/test/test_utils"
+	"github.com/vmware-tanzu/dependency-labeler/test/test_utils"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/test/integration/rpm_integration_test.go
+++ b/test/integration/rpm_integration_test.go
@@ -10,7 +10,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 )
 
 var _ = Describe("[rpm] deplab rpm", func() {

--- a/test/test_utils/dependencies.go
+++ b/test/test_utils/dependencies.go
@@ -3,7 +3,7 @@
 
 package test_utils
 
-import "github.com/pivotal/deplab/pkg/metadata"
+import "github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 
 func SelectDpkgDependency(dependencies []metadata.Dependency) (metadata.Dependency, bool) {
 	return metadata.SelectDependency(dependencies, metadata.DebianPackageListSourceType)

--- a/test/test_utils/fixtures.go
+++ b/test/test_utils/fixtures.go
@@ -3,7 +3,7 @@
 
 package test_utils
 
-import "github.com/pivotal/deplab/pkg/metadata"
+import "github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 
 var MetadataSample = metadata.Metadata{
 	Dependencies: []metadata.Dependency{

--- a/test/test_utils/image.go
+++ b/test/test_utils/image.go
@@ -6,7 +6,7 @@ package test_utils
 import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	. "github.com/onsi/gomega"
-	"github.com/pivotal/deplab/pkg/metadata"
+	"github.com/vmware-tanzu/dependency-labeler/pkg/metadata"
 	"path/filepath"
 )
 


### PR DESCRIPTION
As part of making this app open-source, we had to move and rename the original github repo. This move and rename requires
the code to be updated to reference the new repo.

[#174129819]